### PR TITLE
Fix facility level restrictions for EVA report and surface sample

### DIFF
--- a/ScienceAlert.Experiments/EvaReportObserver.cs
+++ b/ScienceAlert.Experiments/EvaReportObserver.cs
@@ -68,5 +68,20 @@ namespace ScienceAlert.Experiments
             var luckyKerbal = crewChoices[UnityEngine.Random.Range(0, crewChoices.Count - 1)];
             return FlightEVA.SpawnEVA(luckyKerbal.KerbalRef);
         }
+
+        public override bool UpdateStatus(ExperimentSituations experimentSituation, out bool newReport)
+        {
+            newReport = false;
+
+            // If the astronaut complex is level 0, EVA is only allowed when landed on the surface.
+            if (ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.AstronautComplex) == 0 && experimentSituation != ExperimentSituations.SrfLanded)
+            {
+                Available = false;
+                lastAvailableId = "";
+                return false;
+            }
+
+            return base.UpdateStatus(experimentSituation, out newReport);
+        }
     }
 }

--- a/ScienceAlert.Experiments/SurfaceSampleObserver.cs
+++ b/ScienceAlert.Experiments/SurfaceSampleObserver.cs
@@ -19,5 +19,20 @@ namespace ScienceAlert.Experiments
                 return Settings.Instance.CheckSurfaceSampleNotEva && base.IsReadyOnboard;
             }
         }
+
+        public override bool UpdateStatus(ExperimentSituations experimentSituation, out bool newReport)
+        {
+            newReport = false;
+
+            // Surface samples are not allowed at astronaut level 0.
+            if (ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.AstronautComplex) == 0)
+            {
+                Available = false;
+                lastAvailableId = "";
+                return false;
+            }
+
+            return base.UpdateStatus(experimentSituation, out newReport);
+        }
     }
 }


### PR DESCRIPTION
Added checks for the EVA report and surface sample to respect the facility level restrictions in career mode.